### PR TITLE
Logic to support schemas with circular refs

### DIFF
--- a/lib/schema-parser.js
+++ b/lib/schema-parser.js
@@ -158,9 +158,38 @@ function _convertJsonSchemaToModel(pathToJsonSchema, modelName, collectionName) 
               this.update({ $ref: "#/definitions/objectid" })
         }
       });
+
+      // 'refSafeSchema' contains a schema without any circular references.
+      // If a schema DOES have circular references, it will be the schema
+      // but without any $refs resolved (as they can't be deseralized!)
+      var refSafeSchema = require(pathToJsonSchema),
+          refs = {},
+          circularReferences =  {};
+      try {
+        var tmpSchema = JSON.stringify(dereferencedJsonSchemaForMongoose);
+        refSafeSchema = dereferencedJsonSchema;
+      } catch (e) {
+        if (e == "TypeError: Converting circular structure to JSON") {
+          console.log("@WARNING Schema '"+ pathToJsonSchema + "' contains circular references.");
+          console.log("@WARNING All $ref values converted to be objects will not be validated.");
+          refSafeSchema = traverse(require(pathToJsonSchema)).map(function(node) {
+              if (node['$ref']) {
+                circularReferences[this.path.join('.')] = node['$ref'];
+                //console.log(" \_ Reference to "+node['$ref']+" at "+this.path.join('.')+" converted to Object ID.");
+                //this.update({ type: 'string', format: 'objectid', pattern: "^[0-9a-fA-F]{24}$", description: node['$ref'] });
+                //console.log(" \_ "+path.basename(pathToJsonSchema)+": Reference to "+node['$ref']+" at "+this.path.join('.')+" converted to URI");
+                //this.update({ type: 'string', format: 'uri', description: node['$ref'] });
+                console.log(" \_ "+path.basename(pathToJsonSchema)+": Reference to "+node['$ref']+" at "+this.path.join('.')+" converted to an object");
+                this.update({ type: 'object', properties: {}, additionalProperties: true, description: node['$ref'] });
+              }
+          });
+        }
+      }
       
-      var mongooseSchema = createMongooseSchema({}, dereferencedJsonSchemaForMongoose);
-      
+      var mongooseSchema = createMongooseSchema(refs, refSafeSchema);
+
+      //return       resolve({ model: mongoose.model(modelName, {}), schema: dereferencedJsonSchema });
+            
       // Add _type field to all models (used to store model name/type)
       mongooseSchema._type = { type: String };
     
@@ -178,7 +207,10 @@ function _convertJsonSchemaToModel(pathToJsonSchema, modelName, collectionName) 
 
         // @TODO Support custom hooks
         // save_hook(this, next(), modelName, collectionName, pathToJsonSchema);
-        _validate(this, dereferencedJsonSchema, next);
+        
+        //@FIXME if circularReferences.length > 0 validate their contents against their schema …recursively?
+        
+        _validate(this, refSafeSchema, next);
       });
     
       // Update hook
@@ -187,8 +219,10 @@ function _convertJsonSchemaToModel(pathToJsonSchema, modelName, collectionName) 
         
         // @TODO Support custom hooks
         // save_hook(this, next(), modelName, collectionName, pathToJsonSchema);
+
+        //@FIXME if circularReferences.length > 0 validate their contents against their schema …recursively?
         
-        _validate(this._update, dereferencedJsonSchema, next);
+        _validate(this._update, refSafeSchema, next);
       });
       
       // Delete hook
@@ -208,7 +242,7 @@ function _convertJsonSchemaToModel(pathToJsonSchema, modelName, collectionName) 
         return serialize.toJSONLD(this.toObject());
       };
 
-      resolve({ model: mongoose.model(modelName, schema), schema: dereferencedJsonSchema });
+      resolve({ model: mongoose.model(modelName, schema), schema: refSafeSchema, circularReferences: circularReferences });
     })
     .catch(function(err) {
       reject(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stuctured-data-api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A platform for working with Structured Data",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
Circular references are now handled by converting the object to be a plain object, with additional properties explicitly allowed. Validation of those objects is currently skipped due to lack of support in the validator for handling circular schemas.

Example of circular reference:

Schema A references schema B, schema B references schema C and schema C references schema A (with any level of indirection). This includes remotely loaded schemas, which are downloaded when the app starts (including any nested references in any of the remotely loaded schemas).

I'm undecided if converting refs that are circular to objects, URIs or Object IDs is best by default, have left commented out code for all options and make make this behaviour configurable at run time, but currently it's objects.

I am considering if I want to try and add a custom validation routine to deal with validating these objects but that seems like it might be a bit of a rabbit hole and just converting them to Object IDs or URIs would be easier but would also make things more complicated on the client.

The Popolo schemas are unusually complicated, which is what has prompted this.
